### PR TITLE
Logic for changing the file name before render && Warning that the file already exists

### DIFF
--- a/backend/src/ffmpeg/encoders.rs
+++ b/backend/src/ffmpeg/encoders.rs
@@ -69,7 +69,7 @@ impl Encoder {
                 "libx264", Codec::H264, false,
                 Some(&["-crf", "19", "-b:v", "0k"])
             ),
-            
+
             Encoder::new_with_extra_args(
                 "libx265", Codec::H265, false,
                 Some(&["-crf", "20", "-b:v", "0k"]),
@@ -168,7 +168,7 @@ impl Encoder {
                 "prores_videotoolbox", Codec::ProRes, true,
                 None,
                 &["-profile:v", "4", "-pix_fmt", "yuva422p10le", "-alpha_bits", "8", "-vendor", "apl0"]
-            ),            
+            ),
         ];
 
         all_encoders

--- a/backend/src/font/dimensions.rs
+++ b/backend/src/font/dimensions.rs
@@ -3,9 +3,8 @@ use std::fmt::Display;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
-use crate::util::Dimension;
-
 use super::FontFileError;
+use crate::util::Dimension;
 
 #[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize, Derivative)]
 pub enum CharacterSizeClass {

--- a/backend/src/font/font_file.rs
+++ b/backend/src/font/font_file.rs
@@ -1,13 +1,12 @@
 use std::{
     cell::RefCell,
+    collections::HashMap,
     hash::{DefaultHasher, Hash, Hasher},
     path::PathBuf,
 };
 
 use derivative::Derivative;
 use image::{imageops::FilterType, io::Reader, DynamicImage, GenericImageView, ImageBuffer, Rgba, RgbaImage};
-
-use std::collections::HashMap;
 
 // Cache structure
 #[derive(Derivative, Clone, Debug)]
@@ -40,12 +39,11 @@ impl ImageCache {
     }
 }
 
-use crate::util::Dimension;
-
 use super::{
     dimensions::{detect_font_character_size, CharacterSizeClass, FontType},
     error::FontFileError,
 };
+use crate::util::Dimension;
 
 #[derive(Derivative, Clone)]
 #[derivative(Debug)]

--- a/backend/src/overlay/iter.rs
+++ b/backend/src/overlay/iter.rs
@@ -7,7 +7,6 @@ use ffmpeg_sidecar::{
     iter::FfmpegIterator,
 };
 use image::{Rgba, RgbaImage};
-use rayon::iter::Empty;
 
 use super::{overlay_osd, overlay_srt_data, overlay_srt_debug_data};
 use crate::{

--- a/backend/src/overlay/osd.rs
+++ b/backend/src/overlay/osd.rs
@@ -1,5 +1,6 @@
-use image::{imageops::overlay, RgbaImage};
 use std::time::Instant;
+
+use image::{imageops::overlay, RgbaImage};
 
 use crate::{
     ffmpeg,

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -28,7 +28,7 @@ use crate::{
 #[derive(Default)]
 pub struct WalksnailOsdTool {
     pub config_changed: Option<Instant>,
-    pub video_file: Option<PathBuf>,
+    pub input_video_file: Option<PathBuf>,
     pub output_video_file: Option<PathBuf>,
     pub video_info: Option<VideoInfo>,
     pub osd_file: Option<OsdFile>,

--- a/ui/src/app.rs
+++ b/ui/src/app.rs
@@ -29,6 +29,7 @@ use crate::{
 pub struct WalksnailOsdTool {
     pub config_changed: Option<Instant>,
     pub video_file: Option<PathBuf>,
+    pub output_video_file: Option<PathBuf>,
     pub video_info: Option<VideoInfo>,
     pub osd_file: Option<OsdFile>,
     pub font_file: Option<FontFile>,
@@ -47,6 +48,7 @@ pub struct WalksnailOsdTool {
     pub srt_options: SrtOptions,
     pub srt_font: Option<rusttype::Font<'static>>,
     pub about_window_open: bool,
+    pub filename_set: bool,
     pub dark_mode: bool,
     pub app_update: AppUpdate,
     pub app_version: String,

--- a/ui/src/bottom_panel.rs
+++ b/ui/src/bottom_panel.rs
@@ -2,7 +2,7 @@ use backend::ffmpeg::{start_video_render, ToFfmpegMessage};
 use egui::{vec2, Align, Button, Color32, Layout, ProgressBar, RichText, Ui};
 
 use super::{util::format_minutes_seconds, WalksnailOsdTool};
-use crate::{render_status::Status, util::get_output_video_path};
+use crate::render_status::Status;
 
 impl WalksnailOsdTool {
     pub fn render_bottom_panel(&mut self, ctx: &egui::Context) {
@@ -30,8 +30,9 @@ impl WalksnailOsdTool {
             {
                 tracing::info!("Start render button clicked");
                 self.render_status.start_render();
-                if let (Some(video_path), Some(osd_file), Some(font_file), Some(video_info), Some(encoder)) = (
+                if let (Some(input_video_path), Some(output_video_path), Some(osd_file), Some(font_file), Some(video_info), Some(encoder)) = (
                     &self.video_file,
+                    &self.output_video_file,
                     &self.osd_file,
                     &self.font_file,
                     &self.video_info,
@@ -46,8 +47,8 @@ impl WalksnailOsdTool {
                     };
                     match start_video_render(
                         &self.dependencies.ffmpeg_path,
-                        video_path,
-                        &get_output_video_path(video_path),
+                        input_video_path,
+                        output_video_path,
                         osd_file.frames.clone(),
                         self.srt_file.as_ref().map(|file| file.frames.clone()),
                         font_file.clone(),

--- a/ui/src/bottom_panel.rs
+++ b/ui/src/bottom_panel.rs
@@ -30,7 +30,14 @@ impl WalksnailOsdTool {
             {
                 tracing::info!("Start render button clicked");
                 self.render_status.start_render();
-                if let (Some(input_video_path), Some(output_video_path), Some(osd_file), Some(font_file), Some(video_info), Some(encoder)) = (
+                if let (
+                    Some(input_video_path),
+                    Some(output_video_path),
+                    Some(osd_file),
+                    Some(font_file),
+                    Some(video_info),
+                    Some(encoder),
+                ) = (
                     &self.input_video_file,
                     &self.output_video_file,
                     &self.osd_file,

--- a/ui/src/bottom_panel.rs
+++ b/ui/src/bottom_panel.rs
@@ -31,7 +31,7 @@ impl WalksnailOsdTool {
                 tracing::info!("Start render button clicked");
                 self.render_status.start_render();
                 if let (Some(input_video_path), Some(output_video_path), Some(osd_file), Some(font_file), Some(video_info), Some(encoder)) = (
-                    &self.video_file,
+                    &self.input_video_file,
                     &self.output_video_file,
                     &self.osd_file,
                     &self.font_file,

--- a/ui/src/central_panel.rs
+++ b/ui/src/central_panel.rs
@@ -12,7 +12,7 @@ use egui::{
 
 use crate::{
     osd_preview::{calculate_horizontal_offset, calculate_vertical_offset},
-    util::{separator_with_space, tooltip_text, handle_file_path_update},
+    util::{handle_file_path_update, separator_with_space, tooltip_text},
     WalksnailOsdTool,
 };
 
@@ -475,7 +475,6 @@ impl WalksnailOsdTool {
     }
 
     fn rendering_options(&mut self, ui: &mut Ui) {
-        
         let mut changed = false;
         CollapsingHeader::new(RichText::new("Rendering Options").heading())
             .default_open(true)
@@ -530,7 +529,6 @@ impl WalksnailOsdTool {
                         let selected_encoder = self.get_selected_encoder();
                         let bitrate_enabled = !self.render_settings.keep_quality;
                         let mut constant_quality_available = false;
-                        
                         if let Some(selected_encoder) = selected_encoder {
                             if selected_encoder.constant_quality_args != None {
                                 constant_quality_available = true;

--- a/ui/src/central_panel.rs
+++ b/ui/src/central_panel.rs
@@ -488,7 +488,7 @@ impl WalksnailOsdTool {
                             ui.horizontal(|ui| {
                                 handle_file_path_update(
                                     ui,
-                                    &self.video_file,
+                                    &self.input_video_file,
                                     &mut self.output_video_file,
                                     &mut self.filename_set,
                                     &self.render_status,

--- a/ui/src/central_panel.rs
+++ b/ui/src/central_panel.rs
@@ -12,7 +12,7 @@ use egui::{
 
 use crate::{
     osd_preview::{calculate_horizontal_offset, calculate_vertical_offset},
-    util::{separator_with_space, tooltip_text},
+    util::{separator_with_space, tooltip_text, handle_file_path_update},
     WalksnailOsdTool,
 };
 
@@ -475,6 +475,7 @@ impl WalksnailOsdTool {
     }
 
     fn rendering_options(&mut self, ui: &mut Ui) {
+        
         let mut changed = false;
         CollapsingHeader::new(RichText::new("Rendering Options").heading())
             .default_open(true)
@@ -482,11 +483,23 @@ impl WalksnailOsdTool {
                 Grid::new("render_options")
                     .min_col_width(self.ui_dimensions.options_column1_width)
                     .show(ui, |ui| {
-
-                        let displayed_encoders = self.displayed_encoders();
+                        ui.label("Filename").on_hover_text(tooltip_text("Filename after rendering"));
+                        ui.horizontal(|ui| {
+                            ui.horizontal(|ui| {
+                                handle_file_path_update(
+                                    ui,
+                                    &self.video_file,
+                                    &mut self.output_video_file,
+                                    &mut self.filename_set,
+                                    &self.render_status,
+                                );
+                            });
+                        });
+                        ui.end_row();
 
                         ui.label("Encoder")
                             .on_hover_text(tooltip_text("Encoder used for rendering. In some cases not all available encoders are detected. Check the box to also show these."));
+                        let displayed_encoders = self.displayed_encoders();
                         ui.horizontal(|ui| {
                             let selection = egui::ComboBox::from_id_source("encoder").width(350.0).show_index(
                                 ui,

--- a/ui/src/side_panel.rs
+++ b/ui/src/side_panel.rs
@@ -48,7 +48,7 @@ impl WalksnailOsdTool {
                                     ui.label("File name:");
                                 });
                                 row.col(|ui| {
-                                    if let Some(video_file) = &self.video_file {
+                                    if let Some(video_file) = &self.input_video_file {
                                         ui.label(video_file.file_name().unwrap().to_string_lossy());
                                     } else {
                                         ui.label("-");

--- a/ui/src/top_panel.rs
+++ b/ui/src/top_panel.rs
@@ -36,6 +36,8 @@ impl WalksnailOsdTool {
 
                 self.update_osd_preview(ctx);
                 self.render_status.reset();
+                self.output_video_file = None;
+                self.filename_set = false;
             }
         }
 
@@ -55,6 +57,8 @@ impl WalksnailOsdTool {
             self.import_srt_file(&file_handles);
             self.update_osd_preview(ctx);
             self.render_status.reset();
+            self.output_video_file = None;
+            self.filename_set = false;
         }
     }
 
@@ -71,6 +75,8 @@ impl WalksnailOsdTool {
             self.osd_preview.texture_handle = None;
             self.osd_preview.preview_frame = 1;
             self.render_status.reset();
+            self.output_video_file = None;
+            self.filename_set = false;
             tracing::info!("Reset files");
         }
     }

--- a/ui/src/top_panel.rs
+++ b/ui/src/top_panel.rs
@@ -67,7 +67,7 @@ impl WalksnailOsdTool {
             .add_enabled(self.render_status.is_not_in_progress(), Button::new("Reset files"))
             .clicked()
         {
-            self.video_file = None;
+            self.input_video_file = None;
             self.video_info = None;
             self.osd_file = None;
             self.font_file = None;

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -1,7 +1,7 @@
 use std::{
     env::current_exe,
     path::{Path, PathBuf},
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use backend::{config::AppConfig, ffmpeg::VideoInfo, font::FontFile, osd::OsdFile, srt::SrtFile};
@@ -105,7 +105,9 @@ pub fn format_minutes_seconds(duration: &Duration) -> String {
 
 pub fn get_output_video_path(input_video_path: &Path) -> PathBuf {
     let input_video_file_name = input_video_path.file_stem().unwrap().to_string_lossy();
-    let output_video_file_name = format!("{}_with_osd.mp4", input_video_file_name);
+    
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();
+    let output_video_file_name = format!("{}_with_osd_{}.mp4", input_video_file_name, timestamp);
     let mut output_video_path = input_video_path.parent().unwrap().to_path_buf();
     output_video_path.push(output_video_file_name);
     output_video_path

--- a/ui/src/util.rs
+++ b/ui/src/util.rs
@@ -20,7 +20,7 @@ impl WalksnailOsdTool {
     }
 
     pub fn video_loaded(&self) -> bool {
-        self.video_file.is_some() && self.video_info.is_some()
+        self.input_video_file.is_some() && self.video_info.is_some()
     }
 
     pub fn osd_loaded(&self) -> bool {
@@ -37,7 +37,7 @@ impl WalksnailOsdTool {
 
     pub fn import_video_file(&mut self, file_handles: &[PathBuf]) {
         if let Some(video_file) = filter_file_with_extention(file_handles, "mp4") {
-            self.video_file = Some(video_file.clone());
+            self.input_video_file = Some(video_file.clone());
             self.video_info = VideoInfo::get(video_file, &self.dependencies.ffprobe_path).ok();
 
             // Try to load the matching OSD and SRT files


### PR DESCRIPTION
Added functionality to manage the output file name before rendering. 

If a file with the specified name already exists, a warning notification is displayed to alert the user about the potential overwrite.

![image](https://github.com/user-attachments/assets/b1219816-6bdf-4eb2-bfad-cda44b6e20f9)
